### PR TITLE
Revert Coloring Creation back to original DMO state

### DIFF
--- a/src/DMO/DmoMesh.h
+++ b/src/DMO/DmoMesh.h
@@ -197,22 +197,11 @@ namespace DMO {
 
             for( const auto& vh: vhs ) {
                 unsigned long colorBits = 0;
-                auto heh                = vh.out().prev().opp().next();
-                const auto heh_init     = heh;
-                do {
-                    int c = colorScheme[heh.from().idx()];
+                for( auto vv: vh.vertices() ) {
+                    int c = colorScheme[vv.idx()];
                     if( c >= 0 )
                         colorBits |= 1 << c;
-                    heh = heh.next();
-                    if( heh.to() == vh ) {
-                        heh = heh.opp();
-                        if( heh.is_boundary() )
-                            break;
-                        else
-                            heh = heh.next();
-                    }
-                } while( heh != heh_init );
-
+                }
                 int color = 0;
                 while( ( colorBits & ( 1 << color ) ) ) {
                     ++color;
@@ -270,22 +259,11 @@ namespace DMO {
                     continue;
 
                 unsigned long colorBits = 0;
-                auto heh                = vh.out().prev().opp().next();
-                const auto heh_init     = heh;
-                do {
-                    int c = colorScheme[heh.from().idx()];
+                for( auto vv: vh.vertices() ) {
+                    int c = colorScheme[vv.idx()];
                     if( c >= 0 )
                         colorBits |= 1 << c;
-                    heh = heh.next();
-                    if( heh.to() == vh ) {
-                        heh = heh.opp();
-                        if( heh.is_boundary() )
-                            break;
-                        else
-                            heh = heh.next();
-                    }
-                } while( heh != heh_init );
-
+                }
                 int color = 0;
                 while( ( colorBits & ( 1 << color ) ) ) {
                     ++color;


### PR DESCRIPTION
Creation of Coloring diverted from Original DMO state reference  [https://github.com/daniel-zint/hpmeshgen/blob/main/src/DMO/DmoMesh.h](url)


This lead to coloring with 2 adjacent neighbors.


For a reproduction of the problem view:  [standalone_DMO_problem.zip](https://github.com/user-attachments/files/15841832/standalone_DMO_problem.zip)

Compile with 
```
g++ -o example show_non_deterministic_behaviour_DMO.cpp -I$PATH/OpenMesh-8.1/build/include -L$PATH/OpenMesh-8.1/build/lib -lOpenMeshCore
```

and with` -DDMO_FIX_COLORING `for checking out the fixed / reverted version