### PR TITLE
Fix ABI Problem for thrust

### DIFF
--- a/src/DMO/DmoVector.h
+++ b/src/DMO/DmoVector.h
@@ -9,8 +9,8 @@ namespace DMO {
 
 #ifdef _DMO_USE_CUDA
     template<typename T> class DmoVectorGPU {
-        thrust::host_vector<T> h_;
-        thrust::device_vector<T> d_;
+        std::vector<T> h_;
+        DMO::detail::device_vector<T> d_;
 
       public:
         const auto& h() const { return h_; }
@@ -20,7 +20,7 @@ namespace DMO {
 
         void copyHostToDevice() { d_ = h_; }
 
-        void copyDeviceToHost() { h_ = d_; }
+        void copyDeviceToHost() { thrust::copy( std::begin( d_ ), std::end( d_ ), std::begin( h_ ) ); }
     };
 #endif    // _DMO_USE_CUDA
 

--- a/src/DMO/Solver.h
+++ b/src/DMO/Solver.h
@@ -8,22 +8,21 @@
 #include "device_launch_parameters.h"
 #include "gpuErrchk.h"
 #include "math_constants.h"
-#include "thrust/device_vector.h"
-#include "thrust/host_vector.h"
 
 #include <type_traits>
 
 namespace DMO {
-    // CUDA kernel
-    template<typename MetricT> void dmoGPU( thrust::device_vector<float2>& points_d, DmoMesh<true>& dmoMesh1_, const MetricT& metric );
+    namespace detail {
+        // CUDA kernel
+        template<typename MetricT> void dmoGPU( float2* const points_d, DmoMesh<true>& dmoMesh1_, const MetricT& metric );
+    }    // namespace detail
 
     template<typename MeshT, typename MetricT, typename Metric2T = DMO::Metrics::NoMetric> class Solver {
         MeshT& mesh_;
         MetricT* metric1_;
         Metric2T* metric2_;
 
-        thrust::host_vector<float2> points_;
-        thrust::device_vector<float2> points_d_;
+        DmoVector<float2> points_;
 
         DmoMesh<true>* dmoMesh1_;
         DmoMesh<true>* dmoMesh2_;
@@ -45,12 +44,12 @@ namespace DMO {
     Solver<MeshT, MetricT, Metric2T>::Solver( MeshT& mesh, MetricT* metric1, DmoMesh<true>* dmoMesh1, Metric2T* metric2, DmoMesh<true>* dmoMesh2 )
         : mesh_( mesh ), metric1_( metric1 ), metric2_( metric2 ), dmoMesh1_( dmoMesh1 ), dmoMesh2_( dmoMesh2 ) {
         // copy points
-        points_.resize( mesh_.n_vertices() );
+        points_.h().resize( mesh_.n_vertices() );
         for( auto vh: mesh_.vertices() ) {
             auto p            = mesh_.point( vh );
-            points_[vh.idx()] = { p[0], p[1] };
+            points_.h()[vh.idx()] = { p[0], p[1] };
         }
-        points_d_ = points_;
+        points_.copyHostToDevice();
 
         dmoMesh1_->copyHostToDevice();
         if constexpr( !std::is_same<Metric2T, Metrics::NoMetric>::value ) {
@@ -62,16 +61,16 @@ namespace DMO {
 
     template<typename MeshT, typename MetricT, typename Metric2T> void Solver<MeshT, MetricT, Metric2T>::solve( int nIterations ) {
         for( int i = 0; i < nIterations; ++i ) {
-            dmoGPU<MetricT>( points_d_, *dmoMesh1_, *metric1_ );
+            detail::dmoGPU<MetricT>( points_.d().data().get(), *dmoMesh1_, *metric1_ );
             if constexpr( !std::is_same<Metric2T, Metrics::NoMetric>::value ) {
-                dmoGPU<Metric2T>( points_d_, *dmoMesh2_, *metric2_ );
+                detail::dmoGPU<Metric2T>( points_.d().data().get(), *dmoMesh2_, *metric2_ );
             }
         }
-        points_ = points_d_;
+        points_.copyDeviceToHost();
 
         for( const auto& vh: mesh_.vertices() ) {
             int idx          = vh.idx();
-            TriMesh::Point p = { points_[idx].x, points_[idx].y, 0.f };
+            TriMesh::Point p = { points_.h()[idx].x, points_.h()[idx].y, 0.f };
             mesh_.set_point( vh, p );
         }
     }

--- a/src/DMO/SolverCPU.h
+++ b/src/DMO/SolverCPU.h
@@ -10,8 +10,10 @@
 #include <vector>
 
 namespace DMO {
-    // CPU kernel
-    template<typename MetricT> void dmoCPU( std::vector<float2>& points, DmoMesh<false>& dmoMesh1_, const MetricT& metric );
+    namespace detail {
+        // CPU kernel
+        template<typename MetricT> void dmoCPU( std::vector<float2>& points, DmoMesh<false>& dmoMesh1_, const MetricT& metric );
+    }    // namespace detail
 
     template<typename MeshT, typename MetricT, typename Metric2T = DMO::Metrics::NoMetric> class SolverCPU {
         MeshT& mesh_;
@@ -50,9 +52,9 @@ namespace DMO {
 
     template<typename MeshT, typename MetricT, typename Metric2T> void SolverCPU<MeshT, MetricT, Metric2T>::solve( int nIterations ) {
         for( int i = 0; i < nIterations; ++i ) {
-            dmoCPU<MetricT>( points_, *dmoMesh1_, *metric1_ );
+            detail::dmoCPU<MetricT>( points_, *dmoMesh1_, *metric1_ );
             if constexpr( !std::is_same<Metric2T, DMO::Metrics::NoMetric>::value ) {
-                dmoCPU<Metric2T>( points_, *dmoMesh2_, *metric2_ );
+                detail::dmoCPU<Metric2T>( points_, *dmoMesh2_, *metric2_ );
             }
         }
 

--- a/src/DMO/SolverCPU_impl.h
+++ b/src/DMO/SolverCPU_impl.h
@@ -9,86 +9,88 @@
 #include <type_traits>
 
 namespace DMO {
-    template<typename MetricT>
-    void optimizeHierarchical( const int cid, std::vector<float2>& points, const std::vector<int>& coloredVertexIDs, const int cOff,
-                               const std::vector<DMO::DmoVertex>& vertices, const std::vector<int>& oneRingVec, const MetricT metric ) {
-        const DMO::DmoVertex& v = vertices[coloredVertexIDs[cOff + cid]];
+    namespace detail {
+        template<typename MetricT>
+        void optimizeHierarchical( const int cid, std::vector<float2>& points, const std::vector<int>& coloredVertexIDs, const int cOff,
+                                   const std::vector<DMO::DmoVertex>& vertices, const std::vector<int>& oneRingVec, const MetricT metric ) {
+            const DMO::DmoVertex& v = vertices[coloredVertexIDs[cOff + cid]];
 
-        float q = -FLT_MAX;
+            float q = -FLT_MAX;
 
-        float2 currPos;    // current optimal position
-        float2 maxDist;
+            float2 currPos;    // current optimal position
+            float2 maxDist;
 
-        float2 oneRing[DMO::MAX_ONE_RING_SIZE];
+            float2 oneRing[DMO::MAX_ONE_RING_SIZE];
 
-        // min/max search + loading oneRing
-        {
-            maxDist.x = -FLT_MAX;
-            maxDist.y = -FLT_MAX;
+            // min/max search + loading oneRing
+            {
+                maxDist.x = -FLT_MAX;
+                maxDist.y = -FLT_MAX;
 
-            for( int k = 0; k < v.oneRingSize - 1; ++k ) {
-                float2 vo  = points[oneRingVec[v.oneRingID + k]];
-                oneRing[k] = vo;
+                for( int k = 0; k < v.oneRingSize - 1; ++k ) {
+                    float2 vo  = points[oneRingVec[v.oneRingID + k]];
+                    oneRing[k] = vo;
 
-                float2 dist = { std::abs( points[v.idx].x - vo.x ), std::abs( points[v.idx].y - vo.y ) };
+                    float2 dist = { std::abs( points[v.idx].x - vo.x ), std::abs( points[v.idx].y - vo.y ) };
 
-                maxDist.x = fmaxf( maxDist.x, dist.x );
-                maxDist.y = fmaxf( maxDist.y, dist.y );
+                    maxDist.x = fmaxf( maxDist.x, dist.x );
+                    maxDist.y = fmaxf( maxDist.y, dist.y );
+                }
+
+                oneRing[v.oneRingSize - 1] = points[oneRingVec[v.oneRingID + v.oneRingSize - 1]];
+
+                currPos = points[v.idx];
             }
 
-            oneRing[v.oneRingSize - 1] = points[oneRingVec[v.oneRingID + v.oneRingSize - 1]];
+            // start depth iteration
+            float depth_scale = DMO::GRID_SCALE;
+            for( int depth = 0; depth < DMO::DEPTH; ++depth ) {
+                float2 aabbMin, aabbMax;    // axis aligned bounding box
+                aabbMin.x = currPos.x - depth_scale * maxDist.x;
+                aabbMin.y = currPos.y - depth_scale * maxDist.y;
+                aabbMax.x = currPos.x + depth_scale * maxDist.x;
+                aabbMax.y = currPos.y + depth_scale * maxDist.y;
 
-            currPos = points[v.idx];
-        }
+                float qMax  = -FLT_MAX;
+                float2 pMax = { FLT_MAX, FLT_MAX };
 
-        // start depth iteration
-        float depth_scale = DMO::GRID_SCALE;
-        for( int depth = 0; depth < DMO::DEPTH; ++depth ) {
-            float2 aabbMin, aabbMax;    // axis aligned bounding box
-            aabbMin.x = currPos.x - depth_scale * maxDist.x;
-            aabbMin.y = currPos.y - depth_scale * maxDist.y;
-            aabbMax.x = currPos.x + depth_scale * maxDist.x;
-            aabbMax.y = currPos.y + depth_scale * maxDist.y;
+                for( int i = 0; i < DMO::NQ; ++i ) {
+                    for( int j = 0; j < DMO::NQ; ++j ) {
+                        float2 p = { DMO::AFFINE_FACTOR * ( i * aabbMin.x + ( DMO::NQ - 1 - i ) * aabbMax.x ),
+                                     DMO::AFFINE_FACTOR * ( j * aabbMin.y + ( DMO::NQ - 1 - j ) * aabbMax.y ) };
 
-            float qMax  = -FLT_MAX;
-            float2 pMax = { FLT_MAX, FLT_MAX };
-
-            for( int i = 0; i < DMO::NQ; ++i ) {
-                for( int j = 0; j < DMO::NQ; ++j ) {
-                    float2 p = { DMO::AFFINE_FACTOR * ( i * aabbMin.x + ( DMO::NQ - 1 - i ) * aabbMax.x ),
-                                 DMO::AFFINE_FACTOR * ( j * aabbMin.y + ( DMO::NQ - 1 - j ) * aabbMax.y ) };
-
-                    float q = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], p );
-                    if( q > qMax ) {
-                        qMax = q;
-                        pMax = p;
+                        float q = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], p );
+                        if( q > qMax ) {
+                            qMax = q;
+                            pMax = p;
+                        }
                     }
                 }
+
+                float qOld = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], currPos );
+                if( qMax > qOld ) {
+                    currPos = pMax;
+                }
+
+                // rescale candidate grid to the size of two cells
+                depth_scale *= 2 * DMO::AFFINE_FACTOR;
             }
 
-            float qOld = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], currPos );
-            if( qMax > qOld ) {
-                currPos = pMax;
-            }
-
-            // rescale candidate grid to the size of two cells
-            depth_scale *= 2 * DMO::AFFINE_FACTOR;
+            points[v.idx] = currPos;
         }
 
-        points[v.idx] = currPos;
-    }
-
-    template<typename MetricT> void dmoCPU( std::vector<float2>& points, DmoMesh<false>& dmoMesh1_, const MetricT& metric ) {
-        for( auto colorIt = dmoMesh1_.colorOffset_.begin(); colorIt != dmoMesh1_.colorOffset_.end() - 1; ++colorIt ) {
-            const int nBlocks = *( colorIt + 1 ) - *colorIt;
+        template<typename MetricT> void dmoCPU( std::vector<float2>& points, DmoMesh<false>& dmoMesh1_, const MetricT& metric ) {
+            for( auto colorIt = dmoMesh1_.colorOffset_.begin(); colorIt != dmoMesh1_.colorOffset_.end() - 1; ++colorIt ) {
+                const int nBlocks = *( colorIt + 1 ) - *colorIt;
 #pragma omp parallel for
             for( int i = 0; i < nBlocks; ++i ) {
                 optimizeHierarchical( i, points, dmoMesh1_.coloredVertexIDs.h(), *colorIt, dmoMesh1_.vertices.h(), dmoMesh1_.oneRingVec.h(), metric );
             }
+            }
         }
-    }
+    }    // namespace detail
 }    // namespace DMO
 #undef REGISTER_METRIC
-#define REGISTER_METRIC( metric ) template void DMO::dmoCPU<>( std::vector<float2>&, DMO::DmoMesh<false>&, const metric& );
+#define REGISTER_METRIC( metric ) template void DMO::detail::dmoCPU<>( std::vector<float2>&, DMO::DmoMesh<false>&, const metric& );
 
 #include "../DMO/Metrics.h"

--- a/src/DMO/dmoKernel.cu
+++ b/src/DMO/dmoKernel.cu
@@ -11,119 +11,120 @@
 #include <type_traits>
 
 namespace DMO {
-
-    template<typename T, typename ShuffleType = int> __device__ inline T shfl_xor( T var, unsigned int srcLane, int width = 32 ) {
-        static_assert( sizeof( T ) % sizeof( ShuffleType ) == 0, "Cannot shuffle this type." );
-        ShuffleType* a = reinterpret_cast<ShuffleType*>( &var );
-        for( int i = 0; i < sizeof( T ) / sizeof( ShuffleType ); ++i ) {
-            a[i] = __shfl_xor_sync( 0xFFFFFFFF, a[i], srcLane, width );
-        }
-        return var;
-    }
-
-    template<typename T, typename OP> __device__ inline T warpReduce( T val, OP op ) {
-        static_assert( sizeof( T ) <= 8, "Only 8 byte reductions are supportet." );
-        for( int offset = warpSize >> 1; offset > 0; offset >>= 1 ) {
-            auto v = shfl_xor( val, offset );
-            val    = op( val, v );
-        }
-        return val;
-    }
-
-    template<typename MetricT>
-    __global__ void optimizeHierarchical( float2* points, const int* coloredVertexIDs, const int cOff, const DmoVertex* vertices,
-                                          const int* oneRingVec, const MetricT metric ) {
-        const uint2 idx1 = { threadIdx.x / NQ, threadIdx.x % NQ };
-        const uint2 idx2 = { ( threadIdx.x + NQ * NQ / 2 ) / NQ, ( threadIdx.x + NQ * NQ / 2 ) % NQ };
-
-        const DmoVertex& v = vertices[coloredVertexIDs[cOff + blockIdx.x]];
-
-        float q = -FLT_MAX;
-
-        float2 currPos = points[v.idx];    // current optimal position
-
-        __shared__ float2 oneRing[MAX_ONE_RING_SIZE];
-        float2 maxDist;
-
-        // min/max search + loading oneRing
-        float2 vo;
-        if( threadIdx.x < v.oneRingSize ) {
-            vo                   = points[oneRingVec[v.oneRingID + threadIdx.x]];
-            oneRing[threadIdx.x] = vo;
-        } else {
-            vo = currPos;
-        }
-        __syncwarp();
-
-        maxDist.x = warpReduce( std::abs( currPos.x - vo.x ), []( auto d1, auto d2 ) { return d1 > d2 ? d1 : d2; } );
-        maxDist.y = warpReduce( std::abs( currPos.y - vo.y ), []( auto d1, auto d2 ) { return d1 > d2 ? d1 : d2; } );
-
-        thrust::pair<float, int> opt;
-        opt.first  = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], currPos );
-        opt.second = NQ * NQ;
-
-        // start depth iteration
-        float depth_scale = GRID_SCALE;
-        for( int depth = 0; depth < DEPTH; ++depth ) {
-            float2 aabbMin, aabbMax;    // axis aligned bounding box
-            aabbMin.x = currPos.x - depth_scale * maxDist.x;
-            aabbMin.y = currPos.y - depth_scale * maxDist.y;
-            aabbMax.x = currPos.x + depth_scale * maxDist.x;
-            aabbMax.y = currPos.y + depth_scale * maxDist.y;
-
-            float2 p1 = { AFFINE_FACTOR * ( idx1.x * aabbMin.x + ( NQ - 1 - idx1.x ) * aabbMax.x ),
-                          AFFINE_FACTOR * ( idx1.y * aabbMin.y + ( NQ - 1 - idx1.y ) * aabbMax.y ) };
-            float2 p2 = { AFFINE_FACTOR * ( idx2.x * aabbMin.x + ( NQ - 1 - idx2.x ) * aabbMax.x ),
-                          AFFINE_FACTOR * ( idx2.y * aabbMin.y + ( NQ - 1 - idx2.y ) * aabbMax.y ) };
-
-            float q1 = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], p1 );
-            float q2 = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], p2 );
-            float2 p;
-            if( q1 > q2 ) {
-                q = q1;
-                p = p1;
-            } else {
-                q = q2;
-                p = p2;
+    namespace detail {
+        template<typename T, typename ShuffleType = int> __device__ inline T shfl_xor( T var, unsigned int srcLane, int width = 32 ) {
+            static_assert( sizeof( T ) % sizeof( ShuffleType ) == 0, "Cannot shuffle this type." );
+            ShuffleType* a = reinterpret_cast<ShuffleType*>( &var );
+            for( int i = 0; i < sizeof( T ) / sizeof( ShuffleType ); ++i ) {
+                a[i] = __shfl_xor_sync( 0xFFFFFFFF, a[i], srcLane, width );
             }
+            return var;
+        }
 
-            thrust::pair<float, int> data( q, idx1.x * NQ + idx1.y );
-            data = warpReduce( data, []( auto q1, auto q2 ) { return q1.first > q2.first ? q1 : q2; } );
+        template<typename T, typename OP> __device__ inline T warpReduce( T val, OP op ) {
+            static_assert( sizeof( T ) <= 8, "Only 8 byte reductions are supportet." );
+            for( int offset = warpSize >> 1; offset > 0; offset >>= 1 ) {
+                auto v = shfl_xor( val, offset );
+                val    = op( val, v );
+            }
+            return val;
+        }
 
-            opt = data;
+        template<typename MetricT>
+        __global__ void optimizeHierarchical( float2* const points, const int* coloredVertexIDs, const int cOff, const DmoVertex* vertices,
+                                              const int* oneRingVec, const MetricT metric ) {
+            const uint2 idx1 = { threadIdx.x / NQ, threadIdx.x % NQ };
+            const uint2 idx2 = { ( threadIdx.x + NQ * NQ / 2 ) / NQ, ( threadIdx.x + NQ * NQ / 2 ) % NQ };
 
-            // __syncwarp();
+            const DmoVertex& v = vertices[coloredVertexIDs[cOff + blockIdx.x]];
 
-            float qOld = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], currPos );
+            float q = -FLT_MAX;
 
-            // keep old position if new quality is not better
-            if( q <= qOld ) {
-                p = currPos;
+            float2 currPos = points[v.idx];    // current optimal position
+
+            __shared__ float2 oneRing[MAX_ONE_RING_SIZE];
+            float2 maxDist;
+
+            // min/max search + loading oneRing
+            float2 vo;
+            if( threadIdx.x < v.oneRingSize ) {
+                vo                   = points[oneRingVec[v.oneRingID + threadIdx.x]];
+                oneRing[threadIdx.x] = vo;
+            } else {
+                vo = currPos;
             }
             __syncwarp();
-            currPos.x = __shfl_sync( 0xFFFFFFFF, p.x, opt.second );
-            currPos.y = __shfl_sync( 0xFFFFFFFF, p.y, opt.second );
 
-            // rescale candidate grid to the size of two cells
-            depth_scale *= 2 * AFFINE_FACTOR;
+            maxDist.x = warpReduce( std::abs( currPos.x - vo.x ), []( auto d1, auto d2 ) { return d1 > d2 ? d1 : d2; } );
+            maxDist.y = warpReduce( std::abs( currPos.y - vo.y ), []( auto d1, auto d2 ) { return d1 > d2 ? d1 : d2; } );
+
+            thrust::pair<float, int> opt;
+            opt.first  = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], currPos );
+            opt.second = NQ * NQ;
+
+            // start depth iteration
+            float depth_scale = GRID_SCALE;
+            for( int depth = 0; depth < DEPTH; ++depth ) {
+                float2 aabbMin, aabbMax;    // axis aligned bounding box
+                aabbMin.x = currPos.x - depth_scale * maxDist.x;
+                aabbMin.y = currPos.y - depth_scale * maxDist.y;
+                aabbMax.x = currPos.x + depth_scale * maxDist.x;
+                aabbMax.y = currPos.y + depth_scale * maxDist.y;
+
+                float2 p1 = { AFFINE_FACTOR * ( idx1.x * aabbMin.x + ( NQ - 1 - idx1.x ) * aabbMax.x ),
+                              AFFINE_FACTOR * ( idx1.y * aabbMin.y + ( NQ - 1 - idx1.y ) * aabbMax.y ) };
+                float2 p2 = { AFFINE_FACTOR * ( idx2.x * aabbMin.x + ( NQ - 1 - idx2.x ) * aabbMax.x ),
+                              AFFINE_FACTOR * ( idx2.y * aabbMin.y + ( NQ - 1 - idx2.y ) * aabbMax.y ) };
+
+                float q1 = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], p1 );
+                float q2 = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], p2 );
+                float2 p;
+                if( q1 > q2 ) {
+                    q = q1;
+                    p = p1;
+                } else {
+                    q = q2;
+                    p = p2;
+                }
+
+                thrust::pair<float, int> data( q, idx1.x * NQ + idx1.y );
+                data = warpReduce( data, []( auto q1, auto q2 ) { return q1.first > q2.first ? q1 : q2; } );
+
+                opt = data;
+
+                // __syncwarp();
+
+                float qOld = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], currPos );
+
+                // keep old position if new quality is not better
+                if( q <= qOld ) {
+                    p = currPos;
+                }
+                __syncwarp();
+                currPos.x = __shfl_sync( 0xFFFFFFFF, p.x, opt.second );
+                currPos.y = __shfl_sync( 0xFFFFFFFF, p.y, opt.second );
+
+                // rescale candidate grid to the size of two cells
+                depth_scale *= 2 * AFFINE_FACTOR;
+            }
+
+            // set new position if it is better than the old one
+            float qOld = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], points[v.idx] );
+            if( idx1.x * NQ + idx1.y == opt.second && qOld < q ) {
+                points[v.idx] = currPos;
+            }
         }
 
-        // set new position if it is better than the old one
-        float qOld = metric.vertexQuality( oneRing, v.oneRingSize, points[v.idx], points[v.idx] );
-        if( idx1.x * NQ + idx1.y == opt.second && qOld < q ) {
-            points[v.idx] = currPos;
+        template<typename MetricT> void dmoGPU( float2* const points_d, DmoMesh<true>& dmoMesh1_, const MetricT& metric ) {
+            for( auto colorIt = dmoMesh1_.colorOffset_.begin(); colorIt != dmoMesh1_.colorOffset_.end() - 1; ++colorIt ) {
+                const int nBlocks = *( colorIt + 1 ) - *colorIt;
+                optimizeHierarchical<<<nBlocks, N_THREADS>>>( points_d, dmoMesh1_.coloredVertexIDs.d().data().get(), *colorIt,
+                                                              dmoMesh1_.vertices.d().data().get(), dmoMesh1_.oneRingVec.d().data().get(), metric );
+            }
         }
-    }
-
-    template<typename MetricT> void dmoGPU( thrust::device_vector<float2>& points_d, DmoMesh<true>& dmoMesh1_, const MetricT& metric ) {
-        for( auto colorIt = dmoMesh1_.colorOffset_.begin(); colorIt != dmoMesh1_.colorOffset_.end() - 1; ++colorIt ) {
-            const int nBlocks = *( colorIt + 1 ) - *colorIt;
-            optimizeHierarchical<<<nBlocks, N_THREADS>>>( points_d.data().get(), dmoMesh1_.coloredVertexIDs.d().data().get(), *colorIt,
-                                                          dmoMesh1_.vertices.d().data().get(), dmoMesh1_.oneRingVec.d().data().get(), metric );
-        }
-    }
+    }    // namespace detail
 }    // namespace DMO
 
-#define REGISTER_METRIC( metric ) template void DMO::dmoGPU<>( thrust::device_vector<float2>&, DMO::DmoMesh<true>&, const metric& );
+#define REGISTER_METRIC( metric ) template void DMO::detail::dmoGPU<>( float2* const, DMO::DmoMesh<true>&, const metric& )
 
 #include "Metrics.h"

--- a/src/DMO/types.h
+++ b/src/DMO/types.h
@@ -1,13 +1,20 @@
 #pragma once
 
 #include <cmath>
+#include <type_traits>
 
 #ifdef _DMO_USE_CUDA
 #    include "cuda_runtime.h"
 #    include "device_launch_parameters.h"
 #    include "thrust/device_vector.h"
-#    include "thrust/host_vector.h"
 #    include "vector_types.h"
+
+namespace DMO {
+    namespace detail {
+        template<typename T, typename = std::enable_if_t<std::is_trivial_v<T>>> using device_vector = thrust::device_vector<T>;
+    }
+}    // namespace DMO
+
 #else
 struct float2 {
     float x;


### PR DESCRIPTION
The following ABI problem #7 arose stemming from the fact that:

> [A] thrust:: [..] may have a different ABI if:
> - compiled with different architectures
> - compiled as a CUDA source file (-x cu) vs C++ source (-x cpp)
> [ABI Thrust](https://github.com/nvidia/cccl?tab=readme-ov-file#application-binary-interface-abi)

A fix is proposed:
- instead of using thrust::device_vector, use pointers for the interface, i.e., the functions that are linked between nvcc compiled code and g++ compile source code
- add explicit encapsulation for dmoGPU, dmoCPU
- simplify DmoVectorGPU --> a std::vector is sufficient for the host
- use DmoVector in Solver.h